### PR TITLE
Removed duplicate definition of keyboard_post_init_user in default keymap causing build to fail

### DIFF
--- a/keyboards/cheapino/keymaps/default/keymap.c
+++ b/keyboards/cheapino/keymaps/default/keymap.c
@@ -25,11 +25,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                    KC_LGUI, KC_BSPC, KC_SPC,           KC_SPC,  KC_ENT,  KC_RALT
     )
 };
-
-void keyboard_post_init_user(void) {
-      // Customise these values to desired behaviour
-      debug_enable=true;
-      debug_matrix=true;
-      debug_keyboard=true;
-      //debug_mouse=true;
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Removed duplicate definition of keyboard_post_init_user in default keymap causing build to fail. It is already defined in matrix.c
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR
![Screenshot from 2023-04-22 09-23-55](https://user-images.githubusercontent.com/9927530/233998478-0004484a-ce4a-4378-879e-fab297b766f2.png)

* 

## Checklist

- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
