### PR TITLE
Preserve user RGB setting when unplugging during boot light cycle

### DIFF
--- a/keyboards/cheapino/cheapino.c
+++ b/keyboards/cheapino/cheapino.c
@@ -16,11 +16,11 @@ uint8_t _value;
 // stop us from using the keyboard.
 // https://docs.qmk.fm/#/custom_quantum_functions?id=deferred-executor-registration
 uint32_t flash_led(uint32_t next_trigger_time, void *cb_arg) {
-    rgblight_sethsv(_hue_countdown * 5, 230, 70);
+    rgblight_sethsv_noeeprom(_hue_countdown * 5, 230, 70);
     _hue_countdown--;
     if (_hue_countdown == 0) {
         // Finished, reset to user chosen led color
-        rgblight_sethsv(_hue, _saturation, _value);
+        rgblight_sethsv_noeeprom(_hue, _saturation, _value);
         return 0;
     } else {
         return 50;
@@ -69,7 +69,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     uint8_t sat = rgblight_get_sat();
     uint8_t val = rgblight_get_val();
     uint8_t hue = get_hue(get_highest_layer(state));
-    rgblight_sethsv(hue, sat, val);
+    rgblight_sethsv_noeeprom(hue, sat, val);
     return state;
 }
 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

This change will keep the user RGB setting if the user unplugs the keyboard during the light cycle on boot.
This also avoids writing a bunch to the flash.

P.S. I've been using this keyboard for a good number of months now, I absolutely love it!

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation